### PR TITLE
Fix hextofloat for negative value

### DIFF
--- a/gfort2py/module_parse.py
+++ b/gfort2py/module_parse.py
@@ -122,10 +122,13 @@ def hextofloat(s):
     man, exp = s.split("@")
     exp = int(exp)
     decimal = man.index(".")
+    negative = man[0] == "-"
     man = man[decimal + 1 :]
     man = man.ljust(exp, "0")
     man = man[:exp] + "." + man[exp:]
     man = man + "P0"
+    if negative:
+        man = "-" + man
     return float.fromhex(man)
 
 


### PR DESCRIPTION
The function hextofloat gave absolute value of s before, which is fixed now.