### PR TITLE
Fix NotImplementedError when a derived type has components of derived types.

### DIFF
--- a/gfort2py/fDT.py
+++ b/gfort2py/fDT.py
@@ -33,11 +33,9 @@ class fDT(fVar_t):
     def _init_args(self):
         # Store fVar's for each component
         self._dt_args = {}
-        if not any([var.is_derived() for var in self._dt_obj.dt_components()]):
-            for var in self._dt_obj.dt_components():
-                self._dt_args[var.name] = self.fvar(var, allobjs=self.allobjs)
-        else:
-            raise NotImplementedError
+        for var in self._dt_obj.dt_components():
+            self._dt_args[var.name] = self.fvar(var, allobjs=self.allobjs)
+
 
     def ctype(self):
         if self._ctype is None:
@@ -46,10 +44,15 @@ class fDT(fVar_t):
                 if not var.is_derived():
                     fields.append((var.name, self._dt_args[var.name].ctype()))
                 else:
-                    if var.name not in _all_dts:
-                        _all_dts[var.name] = make_dt(var.name)
+                    var_dt_name = self.allobjs[var.dt_type()].name
+                    if var_dt_name not in _all_dts:
+                        raise Exception(
+                            "var name of {} is not found in _all_dts {}".format(
+                                var_dt_name, _all_dts
+                            )
+                        )
 
-                    fields.append((var.name, _all_dts[var.name]))
+                    fields.append((var.name, _all_dts[var_dt_name]))
 
             class _fDerivedType(ctypes.Structure):
                 _fields_ = fields

--- a/tests/dt.f90
+++ b/tests/dt.f90
@@ -277,4 +277,12 @@ module dt
     end function check_recur
 
 
+    function func_return_s_struct_nested_2() result(s)
+        type(s_struct_nested_2)::s
+        s%a_int = 123
+        s%f_nested%a_int = 234
+        s%f_nested%f_struct%a_int = 345
+    end function func_return_s_struct_nested_2
+
+
 end module dt

--- a/tests/dt_test.py
+++ b/tests/dt_test.py
@@ -173,3 +173,9 @@ class TestDTMethods:
         out, err = capfd.readouterr()
         o = "99 98"
         self.assertEqual(out.strip(), o)
+
+    def test_func_return_s_struct_nested_2(self):
+        y = x.func_return_s_struct_nested_2()
+        self.assertEqual(y.result.a_int, 123)
+        self.assertEqual(y.result.f_nested.a_int, 234)
+        self.assertEqual(y.result.f_nested.f_struct.a_int, 345)


### PR DESCRIPTION
Fill all derived types in `_all_dts` at the very beginnning in `fFort`.