### PR TITLE
Cache assumed-shape array descriptor ctype to fix per-call memory leak

### DIFF
--- a/gfort2py/types/arrays.py
+++ b/gfort2py/types/arrays.py
@@ -486,6 +486,13 @@ class ftype_assumed_size_array(f_type, metaclass=ABCMeta):
         return self._sym.properties.array_spec.rank
 
 
+# Cache of the GFortran array-descriptor ctypes.Structure subclass, keyed by
+# (ndims, is_64bit()). The descriptor layout depends only on these two things,
+# so it can be built once and reused. Rebuilding a fresh Structure subclass on
+# every call leaks memory: CPython's ctypes never frees Structure subclasses.
+_ASSUMED_SHAPE_CTYPE_CACHE: dict = {}
+
+
 class ftype_assumed_shape(f_type, metaclass=ABCMeta):
     dtype = None  # type: ignore[assignment]
     ftype = None  # type: ignore[assignment]
@@ -529,6 +536,11 @@ class ftype_assumed_shape(f_type, metaclass=ABCMeta):
 
     @property
     def ctype(self):
+        _key = (self.ndims, is_64bit())
+        _cached = _ASSUMED_SHAPE_CTYPE_CACHE.get(_key)
+        if _cached is not None:
+            return _cached
+
         if is_64bit():
             _index_t = ctypes.c_int64
             _size_t = ctypes.c_int64
@@ -561,6 +573,7 @@ class ftype_assumed_shape(f_type, metaclass=ABCMeta):
                 ("dims", _bounds14 * self.ndims),
             ]
 
+        _ASSUMED_SHAPE_CTYPE_CACHE[_key] = _fAllocArray
         return _fAllocArray
 
     def __repr__(self):

--- a/tests/leak_regression_test.py
+++ b/tests/leak_regression_test.py
@@ -9,6 +9,7 @@ descriptor class is now cached per ``(ndims, is_64bit())``; this test asserts
 that repeated calls do not create an unbounded number of ``Structure``
 subclasses.
 """
+
 import ctypes
 import gc
 import os

--- a/tests/leak_regression_test.py
+++ b/tests/leak_regression_test.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: GPL-2.0+
+"""Regression test for the assumed-shape array-descriptor leak.
+
+``ftype_assumed_shape.ctype`` used to build a fresh ``ctypes.Structure``
+subclass on every call. CPython never frees ``Structure`` subclasses, so each
+call to a procedure with an assumed-shape array argument leaked memory
+(~16 KB/call, measured) and created a new ``Structure`` subclass. The
+descriptor class is now cached per ``(ndims, is_64bit())``; this test asserts
+that repeated calls do not create an unbounded number of ``Structure``
+subclasses.
+"""
+import ctypes
+import gc
+import os
+
+os.environ["_GFORT2PY_TEST_FLAG"] = "1"
+
+import numpy as np
+
+import gfort2py as gf
+
+from .conftest import build_paths
+
+SO, MOD = build_paths("leak_regression", "leak_regression")
+
+x = gf.fFort(SO, MOD)
+
+
+def _count_ctypes_structure_subclasses():
+    return sum(
+        1
+        for obj in gc.get_objects()
+        if isinstance(obj, type) and issubclass(obj, ctypes.Structure)
+    )
+
+
+def test_assumed_shape_ctype_is_cached():
+    a = np.ones((4, 4), dtype=np.float64, order="F")
+
+    x.bump_assumed_shape_2d(a)  # warm up: first call builds + caches the descriptor
+    gc.collect()
+    before = _count_ctypes_structure_subclasses()
+
+    for _ in range(200):
+        x.bump_assumed_shape_2d(a)
+
+    gc.collect()
+    after = _count_ctypes_structure_subclasses()
+
+    # Pre-fix this grew by ~200 (a new descriptor Structure subclass per call).
+    assert after - before <= 2, (
+        f"{after - before} new ctypes.Structure subclasses created over 200 "
+        "calls; the assumed-shape array descriptor is not being cached"
+    )

--- a/tests/src/leak_regression.f90
+++ b/tests/src/leak_regression.f90
@@ -1,0 +1,10 @@
+module leak_regression
+  implicit none
+contains
+  ! Plain assumed-shape array dummy argument, used to exercise
+  ! ftype_assumed_shape.ctype (the array-descriptor path).
+  subroutine bump_assumed_shape_2d(a)
+    real(8), intent(inout) :: a(:,:)
+    a = a + 1.0d0
+  end subroutine bump_assumed_shape_2d
+end module leak_regression


### PR DESCRIPTION
## Summary

`ftype_assumed_shape.ctype` (in `gfort2py/types/arrays.py`) builds three fresh `ctypes.Structure` subclasses (`_bounds14`, `_dtype_type`, `_fAllocArray`) on **every access**. CPython never frees `Structure` subclasses, so every call to a procedure that has an **assumed-shape array argument** permanently leaks memory and creates new type objects without bound. In a long-running loop that repeatedly calls such a procedure, RSS grows linearly and unboundedly (~16 KB per call in my measurements).

The array-descriptor layout depends only on `(ndims, is_64bit())`, so this PR builds the descriptor class once and caches it keyed on that tuple. Behaviour is unchanged — the descriptor is identical, just reused instead of rebuilt.

## Reproduction (standalone, no external deps beyond gfort2py + gfortran)

`leakmod.f90`:
```fortran
module leakmod
  implicit none
contains
  subroutine bump1d(x)
    real(8), intent(inout) :: x(:)
    x = x + 1.0d0
  end subroutine bump1d
  subroutine bump2d(a)
    real(8), intent(inout) :: a(:,:)
    a = a + 1.0d0
  end subroutine bump2d
end module leakmod
```

`repro.py`:
```python
import os, sys
import numpy as np
import gfort2py as gf

x = gf.fFort("./libleakmod.so", "./leakmod.mod")
_PAGE_KB = os.sysconf("SC_PAGE_SIZE") // 1024
def rss_kb():
    with open("/proc/self/statm") as f:
        return int(f.read().split()[1]) * _PAGE_KB

mode = sys.argv[1] if len(sys.argv) > 1 else "2d"
N = int(sys.argv[2]) if len(sys.argv) > 2 else 20000
if mode == "1d":
    a = np.ones(16, dtype=np.float64, order="F"); call = lambda: x.bump1d(a)
else:
    a = np.ones((16, 16), dtype=np.float64, order="F"); call = lambda: x.bump2d(a)

for _ in range(200): call()          # warm up
start = rss_kb()
for i in range(1, N + 1): call()
end = rss_kb()
print(f"mode={mode} N={N} start={start}KB end={end}KB per_call={(end-start)/N:.4f}KB")
```

Build and run:
```
gfortran -shared -fPIC -O2 -J. -o libleakmod.so leakmod.f90
python repro.py 1d 20000
python repro.py 2d 20000
```

### Before this change (HEAD)
```
mode=1d N=20000 start=46396KB end=367784KB per_call=16.0694KB
mode=2d N=20000 start=46556KB end=372856KB per_call=16.3150KB
```
RSS grows linearly and without bound (~16 KB/call), for both 1D and 2D assumed-shape arguments.

### After this change
```
mode=1d N=20000 start=44472KB end=44920KB per_call=0.0224KB
mode=2d N=20000 start=44432KB end=44892KB per_call=0.0230KB
```
RSS plateaus; the per-call delta trends to zero.

## Tests

- Adds `tests/leak_regression_test.py` (with fixture `tests/src/leak_regression.f90`). It counts live `ctypes.Structure` subclasses across 200 calls to a procedure with an assumed-shape array argument. It **fails before this change** (600 new subclasses — 3 per call) and **passes after** (~0).
- Full existing suite: `351 passed, 23 skipped` (skips are `src15`, which needs gfortran 15; I ran on gfortran 11).

## Root cause detail

`ctype` is a `@property`, so each access re-executes the class statements, defining brand-new `Structure` subclasses. Unlike ctypes *array* types (`base * n`, which CPython interns), `Structure` subclasses are never cached or freed, so each access adds permanent objects. Explicit-shape arguments are unaffected because they go through the array-type path; only the assumed-shape descriptor path rebuilds `Structure` subclasses.
